### PR TITLE
Hierarchical Parallelism for CG Solve in the 2d code

### DIFF
--- a/tealeaf_2d/Makefile
+++ b/tealeaf_2d/Makefile
@@ -25,10 +25,10 @@ default: build
 # TARGET   = <OMP|CUDA|MIC>   : OpenMP, CUDA, MIC native compilation
 # COMPILER = <INTEL|GNU> 	  : Currently tested with Intel, GNU compilers
 # KOKKOS_PATH is the root of Kokkos installation, default to local copy
-TARGET   	 = OMP
-COMPILER 	 = INTEL
-MPI_F90	 	 = mpiifort
-MPI_CPP      = mpiicpc
+TARGET           = OMP
+COMPILER         = GNU
+MPI_F90          = mpif90
+MPI_CPP          = mpicxx
 KOKKOS_PATH ?= ../kokkos_src
 OPTIONS     += #-DENABLE_TIMELOGGING -DENABLE_PROFILING
 EXE 		 = tea_leaf
@@ -55,7 +55,7 @@ FLAGS_XL       = -O5 -qipa=partition=large -g -qfullpath -Q -qsigtrap -qextname=
 CFLAGS_          = -O3
 CFLAGS_INTEL     = -O3 -march=native -no-prec-div -restrict -fno-alias 
 CFLAGS_SUN       = -fast -xipo=2
-CFLAGS_GNU       = -O3 -march=native -funroll-loops
+CFLAGS_GNU       = -O3 -march=native -funroll-loops -DKOKKOSP_ENABLE_PROFILING
 CFLAGS_CRAY      = -em -h list=a
 CFLAGS_PGI       = -fastsse -gopt -Mipa=fast -Mlist
 CFLAGS_PATHSCALE = -O3


### PR DESCRIPTION
Hi

this is addresses a big chunk of the performance issue on MIC in native mode. Investigations in stand alone kernels showed that the if conditions on not executing on the halo of the mesh trips the compiler into some weird mode where it generates all kinds of breaks. As a consequent the code is much much slower than it should be. The change also appears to help the Cuda and CPU runtimes albeit much less dramatically. I didn't experiment with team sizes, should be 1 for CPUs and KNC right now. t didn't touch the other solvers but would assume that changes along the lines I did should be easily transferable. 
To enable this add -DUSE_TEAMS to the CFLAGS.

Another thing to consider is to actually use 2D Views for all fields. That would eliminate all the explicit index calculations in the code (or at least the hand coded macros).

Here is some performance data:

KNC (57 core variant)
  OMP_NUM_THREADS=224
  KMP_AFFINITY=compact
  Compiler Intel 15.2.164
  Mesh 2048x2048
  Flat mode: 412s
  Team mode: 167s

K20x 
  Compiler CUDA 7.0.28/GCC 4.7.2
  Mesh 4096x4096
  Flat mode: 611s
  Team mode: 550s

SNB (
  OMP_NUM_THREADS=32
  KMP_AFFINITY=compact
  Compiler Intel 15.2.164
  Mesh 4096x4096
  Flat mode: 1139s
  Team mode: 1079s
