### PR TITLE
Correct MPI communication and additional original benchmarks

### DIFF
--- a/2d/Benchmarks/tea_bm_1.in
+++ b/2d/Benchmarks/tea_bm_1.in
@@ -1,0 +1,19 @@
+*tea
+state 1 density=100.0 energy=0.0001
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0
+x_cells=10
+y_cells=10
+xmin=0.0
+ymin=0.0
+xmax=10.0
+ymax=10.0
+initial_timestep=0.004
+end_step=10
+tl_max_iters=10000
+tl_use_cg
+tl_eps 1.0e-15
+test_problem 1
+*endtea

--- a/2d/Benchmarks/tea_bm_1.out
+++ b/2d/Benchmarks/tea_bm_1.out
@@ -1,0 +1,189 @@
+ 
+   Tea Version    1.402
+       MPI Version
+    OpenMP Version
+   Task Count      1
+ Thread Count:     1
+ 
+ Tea will run from the following input:-
+ 
+*tea                                                                                                
+state 1 density=100.0 energy=0.0001                                                                 
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0              
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0               
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0               
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0              
+x_cells=10                                                                                          
+y_cells=10                                                                                          
+xmin=0.0                                                                                            
+ymin=0.0                                                                                            
+xmax=10.0                                                                                           
+ymax=10.0                                                                                           
+initial_timestep=0.004                                                                              
+end_step=10                                                                                         
+tl_max_iters=10000                                                                                  
+tl_use_cg                                                                                           
+tl_eps 1.0e-15                                                                                      
+test_problem 1                                                                                      
+*endtea                                                                                             
+ 
+ Initialising and generating
+ 
+ Reading input file
+ 
+ Reading specification for state            1
+ 
+            state density   0.1000E+03
+             state energy   0.1000E-03
+ 
+ Reading specification for state            2
+ 
+            state density   0.1000E+00
+             state energy   0.2500E+02
+ state geometry rectangular
+               state xmin   0.0000E+00
+               state xmax   0.1000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            3
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.1000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            4
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.8000E+01
+ 
+ Reading specification for state            5
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.1000E+02
+               state ymin   0.7000E+01
+               state ymax   0.8000E+01
+ 
+                   x_cells          10
+                   y_cells          10
+                      xmin  0.0000E+00
+                      ymin  0.0000E+00
+                      xmax  0.1000E+02
+                      ymax  0.1000E+02
+         initial_timestep   0.4000E-02
+                  end_step          10
+              test_problem           1
+       tl_ppcg_inner_steps          12
+           tiles per task            1
+ 
+ Using Fortran Kernels
+ 
+ Input read finished.
+ 
+ Setting up initial geometry
+ 
+ 
+ Mesh ratio of    1.000000    
+ Decomposing the mesh into            1  by            1  chunks
+ 
+ 
+ Decomposing each chunk into            1  by            1  tiles
+ 
+ Generating chunk
+ 
+ Problem initialised and generated
+ 
+ Time   0.000000000000000E+000
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:      0   0.10000000000000000E+03   0.84016000000000022E+04   0.84016000000000020E+02   0.34899999999999811E+01   0.84265000000000015E+02
+ 
+ Starting the calculation
+ Step       1 time   0.0000000 timestep   4.00E-03
+Conduction error  0.6392003E-15
+Iteration count       10
+ Wall clock   1.080036163330078E-004
+ Average time per cell   1.080036163330078E-006
+ Step time per cell      1.070499420166016E-006
+ Step       2 time   0.0040000 timestep   4.00E-03
+Conduction error  0.6682117E-15
+Iteration count       10
+ Wall clock   1.740455627441406E-004
+ Average time per cell   8.702278137207031E-007
+ Step time per cell      5.102157592773438E-007
+ Step       3 time   0.0080000 timestep   4.00E-03
+Conduction error  0.6987739E-15
+Iteration count       10
+ Wall clock   2.410411834716797E-004
+ Average time per cell   8.034706115722657E-007
+ Step time per cell      5.292892456054688E-007
+ Step       4 time   0.0120000 timestep   4.00E-03
+Conduction error  0.7304637E-15
+Iteration count       10
+ Wall clock   3.039836883544922E-004
+ Average time per cell   7.599592208862305E-007
+ Step time per cell      5.197525024414063E-007
+ Step       5 time   0.0160000 timestep   4.00E-03
+Conduction error  0.7627153E-15
+Iteration count       10
+ Wall clock   3.681182861328125E-004
+ Average time per cell   7.362365722656250E-007
+ Step time per cell      5.102157592773438E-007
+ Step       6 time   0.0200000 timestep   4.00E-03
+Conduction error  0.7948280E-15
+Iteration count       10
+ Wall clock   4.310607910156250E-004
+ Average time per cell   7.184346516927083E-007
+ Step time per cell      5.102157592773438E-007
+ Step       7 time   0.0240000 timestep   4.00E-03
+Conduction error  0.8259878E-15
+Iteration count       10
+ Wall clock   4.920959472656250E-004
+ Average time per cell   7.029942103794642E-007
+ Step time per cell      4.911422729492188E-007
+ Step       8 time   0.0280000 timestep   4.00E-03
+Conduction error  0.8553014E-15
+Iteration count       10
+ Wall clock   5.519390106201172E-004
+ Average time per cell   6.899237632751464E-007
+ Step time per cell      4.792213439941406E-007
+ Step       9 time   0.0320000 timestep   4.00E-03
+Conduction error  0.8818444E-15
+Iteration count       10
+ Wall clock   6.120204925537109E-004
+ Average time per cell   6.800227695041233E-007
+ Step time per cell      4.792213439941406E-007
+ Step      10 time   0.0360000 timestep   4.00E-03
+Conduction error  0.9047197E-15
+Iteration count       10
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000000000E+03   0.84016000000000022E+04   0.84016000000000020E+02   0.34899999999999927E+01   0.15755084183279294E+03
+ 
+ Wall clock   7.069110870361328E-004
+ Average time per cell   7.069110870361328E-007
+ Step time per cell      8.177757263183594E-007
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000000000E+03   0.84016000000000022E+04   0.84016000000000020E+02   0.34899999999999927E+01   0.15755084183279294E+03
+ 
+Test problem   1 is within   0.0000000E+00% of the expected solution
+ This test is considered PASSED
+ 
+ Calculation complete
+ Tea is finishing
+ First step overhead  5.698204040527344E-005
+ Wall clock   7.550716400146484E-004

--- a/2d/Benchmarks/tea_bm_2.in
+++ b/2d/Benchmarks/tea_bm_2.in
@@ -1,0 +1,19 @@
+*tea
+state 1 density=100.0 energy=0.0001
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0
+x_cells=250
+y_cells=250
+xmin=0.0
+ymin=0.0
+xmax=10.0
+ymax=10.0
+initial_timestep=0.004
+end_step=10
+tl_max_iters=10000
+tl_use_cg
+tl_eps 1.0e-15
+test_problem 2
+*endtea

--- a/2d/Benchmarks/tea_bm_2.out
+++ b/2d/Benchmarks/tea_bm_2.out
@@ -1,0 +1,189 @@
+ 
+   Tea Version    1.402
+       MPI Version
+    OpenMP Version
+   Task Count      1
+ Thread Count:     1
+ 
+ Tea will run from the following input:-
+ 
+*tea                                                                                                
+state 1 density=100.0 energy=0.0001                                                                 
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0              
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0               
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0               
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0              
+x_cells=250                                                                                         
+y_cells=250                                                                                         
+xmin=0.0                                                                                            
+ymin=0.0                                                                                            
+xmax=10.0                                                                                           
+ymax=10.0                                                                                           
+initial_timestep=0.004                                                                              
+end_step=10                                                                                         
+tl_max_iters=10000                                                                                  
+tl_use_cg                                                                                           
+tl_eps 1.0e-15                                                                                      
+test_problem 2                                                                                      
+*endtea                                                                                             
+ 
+ Initialising and generating
+ 
+ Reading input file
+ 
+ Reading specification for state            1
+ 
+            state density   0.1000E+03
+             state energy   0.1000E-03
+ 
+ Reading specification for state            2
+ 
+            state density   0.1000E+00
+             state energy   0.2500E+02
+ state geometry rectangular
+               state xmin   0.0000E+00
+               state xmax   0.1000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            3
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.1000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            4
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.8000E+01
+ 
+ Reading specification for state            5
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.1000E+02
+               state ymin   0.7000E+01
+               state ymax   0.8000E+01
+ 
+                   x_cells         250
+                   y_cells         250
+                      xmin  0.0000E+00
+                      ymin  0.0000E+00
+                      xmax  0.1000E+02
+                      ymax  0.1000E+02
+         initial_timestep   0.4000E-02
+                  end_step          10
+              test_problem           2
+       tl_ppcg_inner_steps          60
+           tiles per task            1
+ 
+ Using Fortran Kernels
+ 
+ Input read finished.
+ 
+ Setting up initial geometry
+ 
+ 
+ Mesh ratio of    1.000000    
+ Decomposing the mesh into            1  by            1  chunks
+ 
+ 
+ Decomposing each chunk into            1  by            1  tiles
+ 
+ Generating chunk
+ 
+ Problem initialised and generated
+ 
+ Time   0.000000000000000E+000
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:      0   0.99999999999980361E+02   0.84015999999931973E+04   0.84015999999948477E+02   0.34900000000008937E+01   0.84265000000004491E+02
+ 
+ Starting the calculation
+ Step       1 time   0.0000000 timestep   4.00E-03
+Conduction error  0.9917184E-15
+Iteration count      228
+ Wall clock   0.121075868606567     
+ Average time per cell   1.937213897705078E-006
+ Step time per cell      1.937213897705078E-006
+ Step       2 time   0.0040000 timestep   4.00E-03
+Conduction error  0.9290535E-15
+Iteration count      242
+ Wall clock   0.247363805770874     
+ Average time per cell   1.978910446166992E-006
+ Step time per cell      2.020381927490234E-006
+ Step       3 time   0.0080000 timestep   4.00E-03
+Conduction error  0.8487204E-15
+Iteration count      244
+ Wall clock   0.374176025390625     
+ Average time per cell   1.995605468750000E-006
+ Step time per cell      2.028800964355469E-006
+ Step       4 time   0.0120000 timestep   4.00E-03
+Conduction error  0.8810895E-15
+Iteration count      238
+ Wall clock   0.497560977935791     
+ Average time per cell   1.990243911743164E-006
+ Step time per cell      1.973968505859375E-006
+ Step       5 time   0.0160000 timestep   4.00E-03
+Conduction error  0.8525188E-15
+Iteration count      231
+ Wall clock   0.617063999176025     
+ Average time per cell   1.974604797363281E-006
+ Step time per cell      1.911872863769531E-006
+ Step       6 time   0.0200000 timestep   4.00E-03
+Conduction error  0.9497803E-15
+Iteration count      222
+ Wall clock   0.749192953109741     
+ Average time per cell   1.997847874959310E-006
+ Step time per cell      2.113887786865235E-006
+ Step       7 time   0.0240000 timestep   4.00E-03
+Conduction error  0.8500275E-15
+Iteration count      215
+ Wall clock   0.876698017120361     
+ Average time per cell   2.003881181989397E-006
+ Step time per cell      2.039905548095703E-006
+ Step       8 time   0.0280000 timestep   4.00E-03
+Conduction error  0.8725096E-15
+Iteration count      208
+ Wall clock   0.999851942062378     
+ Average time per cell   1.999703884124756E-006
+ Step time per cell      1.970287322998047E-006
+ Step       9 time   0.0320000 timestep   4.00E-03
+Conduction error  0.9235278E-15
+Iteration count      202
+ Wall clock    1.11894083023071     
+ Average time per cell   1.989228142632378E-006
+ Step time per cell      1.905231475830078E-006
+ Step      10 time   0.0360000 timestep   4.00E-03
+Conduction error  0.9106096E-15
+Iteration count      197
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.99999999999980361E+02   0.84015999999931973E+04   0.84015999999948477E+02   0.34900000000006237E+01   0.10627221178646569E+03
+ 
+ Wall clock    1.23498082160950     
+ Average time per cell   1.975969314575195E-006
+ Step time per cell      1.856445312500000E-006
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.99999999999980361E+02   0.84015999999931973E+04   0.84015999999948477E+02   0.34900000000006237E+01   0.10627221178646569E+03
+ 
+Test problem   2 is within   0.0000000E+00% of the expected solution
+ This test is considered PASSED
+ 
+ Calculation complete
+ Tea is finishing
+ First step overhead -5.198001861572266E-003
+ Wall clock    1.23523283004761     

--- a/2d/Benchmarks/tea_bm_3.in
+++ b/2d/Benchmarks/tea_bm_3.in
@@ -1,0 +1,19 @@
+*tea
+state 1 density=100.0 energy=0.0001
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0
+x_cells=500
+y_cells=500
+xmin=0.0
+ymin=0.0
+xmax=10.0
+ymax=10.0
+initial_timestep=0.004
+end_step=10
+tl_max_iters=10000
+tl_use_cg
+tl_eps 1.0e-15
+test_problem 3
+*endtea

--- a/2d/Benchmarks/tea_bm_3.out
+++ b/2d/Benchmarks/tea_bm_3.out
@@ -1,0 +1,189 @@
+ 
+   Tea Version    1.402
+       MPI Version
+    OpenMP Version
+   Task Count      1
+ Thread Count:     1
+ 
+ Tea will run from the following input:-
+ 
+*tea                                                                                                
+state 1 density=100.0 energy=0.0001                                                                 
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0              
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0               
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0               
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0              
+x_cells=500                                                                                         
+y_cells=500                                                                                         
+xmin=0.0                                                                                            
+ymin=0.0                                                                                            
+xmax=10.0                                                                                           
+ymax=10.0                                                                                           
+initial_timestep=0.004                                                                              
+end_step=10                                                                                         
+tl_max_iters=10000                                                                                  
+tl_use_cg                                                                                           
+tl_eps 1.0e-15                                                                                      
+test_problem 3                                                                                      
+*endtea                                                                                             
+ 
+ Initialising and generating
+ 
+ Reading input file
+ 
+ Reading specification for state            1
+ 
+            state density   0.1000E+03
+             state energy   0.1000E-03
+ 
+ Reading specification for state            2
+ 
+            state density   0.1000E+00
+             state energy   0.2500E+02
+ state geometry rectangular
+               state xmin   0.0000E+00
+               state xmax   0.1000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            3
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.1000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            4
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.8000E+01
+ 
+ Reading specification for state            5
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.1000E+02
+               state ymin   0.7000E+01
+               state ymax   0.8000E+01
+ 
+                   x_cells         500
+                   y_cells         500
+                      xmin  0.0000E+00
+                      ymin  0.0000E+00
+                      xmax  0.1000E+02
+                      ymax  0.1000E+02
+         initial_timestep   0.4000E-02
+                  end_step          10
+              test_problem           3
+       tl_ppcg_inner_steps          88
+           tiles per task            1
+ 
+ Using Fortran Kernels
+ 
+ Input read finished.
+ 
+ Setting up initial geometry
+ 
+ 
+ Mesh ratio of    1.000000    
+ Decomposing the mesh into            1  by            1  chunks
+ 
+ 
+ Decomposing each chunk into            1  by            1  tiles
+ 
+ Generating chunk
+ 
+ Problem initialised and generated
+ 
+ Time   0.000000000000000E+000
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:      0   0.99999999999820304E+02   0.84015999999937685E+04   0.84016000000088653E+02   0.34900000000226834E+01   0.84264999999808950E+02
+ 
+ Starting the calculation
+ Step       1 time   0.0000000 timestep   4.00E-03
+Conduction error  0.9990508E-15
+Iteration count      448
+ Wall clock   0.874023914337158     
+ Average time per cell   3.496095657348633E-006
+ Step time per cell      3.496091842651367E-006
+ Step       2 time   0.0040000 timestep   4.00E-03
+Conduction error  0.9771147E-15
+Iteration count      492
+ Wall clock    1.83277702331543     
+ Average time per cell   3.665554046630859E-006
+ Step time per cell      3.834939956665039E-006
+ Step       3 time   0.0080000 timestep   4.00E-03
+Conduction error  0.9737477E-15
+Iteration count      492
+ Wall clock    2.79145789146423     
+ Average time per cell   3.721943855285644E-006
+ Step time per cell      3.834668159484863E-006
+ Step       4 time   0.0120000 timestep   4.00E-03
+Conduction error  0.9548538E-15
+Iteration count      479
+ Wall clock    3.72494101524353     
+ Average time per cell   3.724941015243530E-006
+ Step time per cell      3.733880043029785E-006
+ Step       5 time   0.0160000 timestep   4.00E-03
+Conduction error  0.9675527E-15
+Iteration count      464
+ Wall clock    5.03431701660156     
+ Average time per cell   4.027453613281250E-006
+ Step time per cell      5.237456321716308E-006
+ Step       6 time   0.0200000 timestep   4.00E-03
+Conduction error  0.9667662E-15
+Iteration count      449
+ Wall clock    6.40107202529907     
+ Average time per cell   4.267381350199382E-006
+ Step time per cell      5.466932296752930E-006
+ Step       7 time   0.0240000 timestep   4.00E-03
+Conduction error  0.9491753E-15
+Iteration count      435
+ Wall clock    7.71828985214233     
+ Average time per cell   4.410451344081334E-006
+ Step time per cell      5.268819808959961E-006
+ Step       8 time   0.0280000 timestep   4.00E-03
+Conduction error  0.9343266E-15
+Iteration count      420
+ Wall clock    8.98387694358826     
+ Average time per cell   4.491938471794129E-006
+ Step time per cell      5.062295913696289E-006
+ Step       9 time   0.0320000 timestep   4.00E-03
+Conduction error  0.9490238E-15
+Iteration count      408
+ Wall clock    10.2077429294586     
+ Average time per cell   4.536774635314941E-006
+ Step time per cell      4.895412445068360E-006
+ Step      10 time   0.0360000 timestep   4.00E-03
+Conduction error  0.9390705E-15
+Iteration count      397
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.99999999999820304E+02   0.84015999999937685E+04   0.84016000000088653E+02   0.34900000000204252E+01   0.99955877498324000E+02
+ 
+ Wall clock    11.3945498466492     
+ Average time per cell   4.557819938659668E-006
+ Step time per cell      4.747175216674805E-006
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.99999999999820304E+02   0.84015999999937685E+04   0.84016000000088653E+02   0.34900000000204252E+01   0.99955877498324000E+02
+ 
+Test problem   3 is within   0.0000000E+00% of the expected solution
+ This test is considered PASSED
+ 
+ Calculation complete
+ Tea is finishing
+ First step overhead -8.471202850341797E-002
+ Wall clock    11.3954010009766     

--- a/2d/Benchmarks/tea_bm_4.in
+++ b/2d/Benchmarks/tea_bm_4.in
@@ -1,0 +1,19 @@
+*tea
+state 1 density=100.0 energy=0.0001
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0
+x_cells=1000
+y_cells=1000
+xmin=0.0
+ymin=0.0
+xmax=10.0
+ymax=10.0
+initial_timestep=0.004
+end_step=10
+tl_max_iters=10000
+tl_use_cg
+tl_eps 1.0e-15
+test_problem 4
+*endtea

--- a/2d/Benchmarks/tea_bm_4.out
+++ b/2d/Benchmarks/tea_bm_4.out
@@ -1,0 +1,189 @@
+ 
+   Tea Version    1.402
+       MPI Version
+    OpenMP Version
+   Task Count      1
+ Thread Count:     1
+ 
+ Tea will run from the following input:-
+ 
+*tea                                                                                                
+state 1 density=100.0 energy=0.0001                                                                 
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0              
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0               
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0               
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0              
+x_cells=1000                                                                                        
+y_cells=1000                                                                                        
+xmin=0.0                                                                                            
+ymin=0.0                                                                                            
+xmax=10.0                                                                                           
+ymax=10.0                                                                                           
+initial_timestep=0.004                                                                              
+end_step=10                                                                                         
+tl_max_iters=10000                                                                                  
+tl_use_cg                                                                                           
+tl_eps 1.0e-15                                                                                      
+test_problem 4                                                                                      
+*endtea                                                                                             
+ 
+ Initialising and generating
+ 
+ Reading input file
+ 
+ Reading specification for state            1
+ 
+            state density   0.1000E+03
+             state energy   0.1000E-03
+ 
+ Reading specification for state            2
+ 
+            state density   0.1000E+00
+             state energy   0.2500E+02
+ state geometry rectangular
+               state xmin   0.0000E+00
+               state xmax   0.1000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            3
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.1000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            4
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.8000E+01
+ 
+ Reading specification for state            5
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.1000E+02
+               state ymin   0.7000E+01
+               state ymax   0.8000E+01
+ 
+                   x_cells        1000
+                   y_cells        1000
+                      xmin  0.0000E+00
+                      ymin  0.0000E+00
+                      xmax  0.1000E+02
+                      ymax  0.1000E+02
+         initial_timestep   0.4000E-02
+                  end_step          10
+              test_problem           4
+       tl_ppcg_inner_steps         124
+           tiles per task            1
+ 
+ Using Fortran Kernels
+ 
+ Input read finished.
+ 
+ Setting up initial geometry
+ 
+ 
+ Mesh ratio of    1.000000    
+ Decomposing the mesh into            1  by            1  chunks
+ 
+ 
+ Decomposing each chunk into            1  by            1  tiles
+ 
+ Generating chunk
+ 
+ Problem initialised and generated
+ 
+ Time   0.000000000000000E+000
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:      0   0.10000000000219612E+03   0.84016000001221310E+04   0.84015999999376220E+02   0.34900000001125400E+01   0.84265000001744184E+02
+ 
+ Starting the calculation
+ Step       1 time   0.0000000 timestep   4.00E-03
+Conduction error  0.9632561E-15
+Iteration count      887
+ Wall clock    7.89020490646362     
+ Average time per cell   7.890204906463624E-006
+ Step time per cell      7.890203952789306E-006
+ Step       2 time   0.0040000 timestep   4.00E-03
+Conduction error  0.9873485E-15
+Iteration count     1000
+ Wall clock    16.7813308238983     
+ Average time per cell   8.390665411949158E-006
+ Step time per cell      8.891094923019410E-006
+ Step       3 time   0.0080000 timestep   4.00E-03
+Conduction error  0.9556009E-15
+Iteration count      993
+ Wall clock    25.6217079162598     
+ Average time per cell   8.540569305419922E-006
+ Step time per cell      8.840349912643433E-006
+ Step       4 time   0.0120000 timestep   4.00E-03
+Conduction error  0.9641309E-15
+Iteration count      964
+ Wall clock    34.1941688060760     
+ Average time per cell   8.548542201519012E-006
+ Step time per cell      8.570946931838989E-006
+ Step       5 time   0.0160000 timestep   4.00E-03
+Conduction error  0.9242069E-15
+Iteration count      936
+ Wall clock    42.5170049667358     
+ Average time per cell   8.503400993347168E-006
+ Step time per cell      8.322810173034669E-006
+ Step       6 time   0.0200000 timestep   4.00E-03
+Conduction error  0.9641245E-15
+Iteration count      906
+ Wall clock    50.5746297836304     
+ Average time per cell   8.429104963938395E-006
+ Step time per cell      8.057600975036621E-006
+ Step       7 time   0.0240000 timestep   4.00E-03
+Conduction error  0.9205744E-15
+Iteration count      882
+ Wall clock    58.4184429645538     
+ Average time per cell   8.345491852079119E-006
+ Step time per cell      7.843789100646973E-006
+ Step       8 time   0.0280000 timestep   4.00E-03
+Conduction error  0.9837094E-15
+Iteration count      850
+ Wall clock    65.9799578189850     
+ Average time per cell   8.247494727373123E-006
+ Step time per cell      7.561490774154663E-006
+ Step       9 time   0.0320000 timestep   4.00E-03
+Conduction error  0.9781952E-15
+Iteration count      828
+ Wall clock    73.3465240001678     
+ Average time per cell   8.149613777796428E-006
+ Step time per cell      7.366543054580689E-006
+ Step      10 time   0.0360000 timestep   4.00E-03
+Conduction error  0.9969501E-15
+Iteration count      808
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000219612E+03   0.84016000001221310E+04   0.84015999999376220E+02   0.34900000001017082E+01   0.97277332050749976E+02
+ 
+ Wall clock    80.5403199195862     
+ Average time per cell   8.054031991958619E-006
+ Step time per cell      7.193772077560425E-006
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000219612E+03   0.84016000001221310E+04   0.84015999999376220E+02   0.34900000001017082E+01   0.97277332050749976E+02
+ 
+Test problem   4 is within   0.0000000E+00% of the expected solution
+ This test is considered PASSED
+ 
+ Calculation complete
+ Tea is finishing
+ First step overhead  -1.00089001655579     
+ Wall clock    80.5437128543854     

--- a/2d/Benchmarks/tea_bm_5.in
+++ b/2d/Benchmarks/tea_bm_5.in
@@ -1,0 +1,20 @@
+*tea
+state 1 density=100.0 energy=0.0001
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0
+x_cells=4000
+y_cells=4000
+xmin=0.0
+ymin=0.0
+xmax=10.0
+ymax=10.0
+initial_timestep=0.004
+end_step=10
+tl_max_iters=10000
+tl_use_cg
+tl_eps 1.0e-15
+test_problem 5
+profiler_on
+*endtea

--- a/2d/Benchmarks/tea_bm_5.out
+++ b/2d/Benchmarks/tea_bm_5.out
@@ -1,0 +1,216 @@
+ 
+   Tea Version    1.402
+       MPI Version
+    OpenMP Version
+   Task Count     24
+ Thread Count:     1
+ 
+ Tea will run from the following input:-
+ 
+*tea                                                                                                
+state 1 density=100.0 energy=0.0001                                                                 
+state 2 density=0.1 energy=25.0 geometry=rectangle xmin=0.0 xmax=1.0 ymin=1.0 ymax=2.0              
+state 3 density=0.1 energy=0.1 geometry=rectangle xmin=1.0 xmax=6.0 ymin=1.0 ymax=2.0               
+state 4 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=6.0 ymin=1.0 ymax=8.0               
+state 5 density=0.1 energy=0.1 geometry=rectangle xmin=5.0 xmax=10.0 ymin=7.0 ymax=8.0              
+x_cells=4000                                                                                        
+y_cells=4000                                                                                        
+xmin=0.0                                                                                            
+ymin=0.0                                                                                            
+xmax=10.0                                                                                           
+ymax=10.0                                                                                           
+initial_timestep=0.004                                                                              
+end_step=10                                                                                         
+tl_max_iters=10000                                                                                  
+tl_use_cg                                                                                           
+tl_eps 1.0e-15                                                                                      
+test_problem 5                                                                                      
+profiler_on                                                                                         
+*endtea                                                                                             
+ 
+ Initialising and generating
+ 
+ Reading input file
+ 
+ Reading specification for state            1
+ 
+            state density   0.1000E+03
+             state energy   0.1000E-03
+ 
+ Reading specification for state            2
+ 
+            state density   0.1000E+00
+             state energy   0.2500E+02
+ state geometry rectangular
+               state xmin   0.0000E+00
+               state xmax   0.1000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            3
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.1000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.2000E+01
+ 
+ Reading specification for state            4
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.6000E+01
+               state ymin   0.1000E+01
+               state ymax   0.8000E+01
+ 
+ Reading specification for state            5
+ 
+            state density   0.1000E+00
+             state energy   0.1000E+00
+ state geometry rectangular
+               state xmin   0.5000E+01
+               state xmax   0.1000E+02
+               state ymin   0.7000E+01
+               state ymax   0.8000E+01
+ 
+                   x_cells        4000
+                   y_cells        4000
+                      xmin  0.0000E+00
+                      ymin  0.0000E+00
+                      xmax  0.1000E+02
+                      ymax  0.1000E+02
+         initial_timestep   0.4000E-02
+                  end_step          10
+              test_problem           5
+               Profiler on
+       tl_ppcg_inner_steps         252
+           tiles per task            1
+ 
+ Using Fortran Kernels
+ 
+ Input read finished.
+ 
+ Setting up initial geometry
+ 
+ 
+ Mesh ratio of    1.000000    
+ Decomposing the mesh into            4  by            6  chunks
+ 
+ 
+ Decomposing each chunk into            1  by            1  tiles
+ 
+ Generating chunk
+ 
+ Problem initialised and generated
+ 
+ Time   0.000000000000000E+000
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:      0   0.10000000000163438E+03   0.84016000001220382E+04   0.84015999999847239E+02   0.34899999999755296E+01   0.84265000001208591E+02
+ 
+ Starting the calculation
+ Step       1 time   0.0000000 timestep   4.00E-03
+Conduction error  0.9975393E-15
+Iteration count     3381
+      Solve Time   52.6244060993    Its   3382     Time Per It    0.0155601437
+ Wall clock    52.6248428821564     
+ Average time per cell   3.289052680134773E-006
+ Step time per cell      3.289052680134773E-006
+ Step       2 time   0.0040000 timestep   4.00E-03
+Conduction error  0.9859480E-15
+Iteration count     4096
+      Solve Time   63.7157959938    Its   4097     Time Per It    0.0155518174
+ Wall clock    116.342077970505     
+ Average time per cell   3.635689936578274E-006
+ Step time per cell      3.982240691781044E-006
+ Step       3 time   0.0080000 timestep   4.00E-03
+Conduction error  0.9843656E-15
+Iteration count     4060
+      Solve Time   63.1831710339    Its   4061     Time Per It    0.0155585252
+ Wall clock    179.525337934494     
+ Average time per cell   3.740111206968626E-006
+ Step time per cell      3.948951184749604E-006
+ Step       4 time   0.0120000 timestep   4.00E-03
+Conduction error  0.9863500E-15
+Iteration count     3950
+      Solve Time   61.4469590187    Its   3951     Time Per It    0.0155522549
+ Wall clock    240.972362041473     
+ Average time per cell   3.765193156898021E-006
+ Step time per cell      3.840437754988670E-006
+ Step       5 time   0.0160000 timestep   4.00E-03
+Conduction error  0.9969900E-15
+Iteration count     3832
+      Solve Time   59.6110148430    Its   3833     Time Per It    0.0155520519
+ Wall clock    300.583441972733     
+ Average time per cell   3.757293024659157E-006
+ Step time per cell      3.725691244006157E-006
+ Step       6 time   0.0200000 timestep   4.00E-03
+Conduction error  0.9923927E-15
+Iteration count     3711
+      Solve Time   57.7479529381    Its   3712     Time Per It    0.0155570994
+ Wall clock    358.331459999084     
+ Average time per cell   3.732619374990463E-006
+ Step time per cell      3.609249874949455E-006
+ Step       7 time   0.0240000 timestep   4.00E-03
+Conduction error  0.9930517E-15
+Iteration count     3603
+      Solve Time   56.0550639629    Its   3604     Time Per It    0.0155535694
+ Wall clock    414.386589050293     
+ Average time per cell   3.699880259377616E-006
+ Step time per cell      3.503444254398346E-006
+ Step       8 time   0.0280000 timestep   4.00E-03
+Conduction error  0.9827599E-15
+Iteration count     3504
+      Solve Time   54.5276057720    Its   3505     Time Per It    0.0155570915
+ Wall clock    468.914259910583     
+ Average time per cell   3.663392655551433E-006
+ Step time per cell      3.407978117465973E-006
+ Step       9 time   0.0320000 timestep   4.00E-03
+Conduction error  0.9973404E-15
+Iteration count     3413
+      Solve Time   53.0984678268    Its   3414     Time Per It    0.0155531540
+ Wall clock    522.012789964676     
+ Average time per cell   3.625088819199138E-006
+ Step time per cell      3.318656876683235E-006
+ Step      10 time   0.0360000 timestep   4.00E-03
+Conduction error  0.9938635E-15
+Iteration count     3340
+      Solve Time   51.9883270264    Its   3341     Time Per It    0.0155607085
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000163438E+03   0.84016000001220382E+04   0.84015999999847239E+02   0.34899999999559252E+01   0.95462351583362249E+02
+ 
+ Wall clock    574.007391929626     
+ Average time per cell   3.587546199560165E-006
+ Step time per cell      3.249661371111870E-006
+ 
+ Time   4.000000000000001E-002
+                                 Volume                      Mass                   Density                    Energy                         U
+ step:     10   0.10000000000163438E+03   0.84016000001220382E+04   0.84015999999847239E+02   0.34899999999559252E+01   0.95462351583362249E+02
+ 
+Test problem   5 is within   0.0000000E+00% of the expected solution
+ This test is considered PASSED
+ 
+ Calculation complete
+ Tea is finishing
+ First step overhead  -11.0910072326660     
+ Wall clock    574.011190891266     
+ 
+Profiler Output                 Time            Percentage
+Timestep              :          0.0075          0.0013
+MPI Halo Exchange     :          3.2786          0.5712
+Self Halo Update      :          0.0427          0.0074
+Internal Halo Update  :          0.0022          0.0004
+Summary               :          0.0092          0.0016
+Visit                 :          0.0000          0.0000
+Tea Init              :          0.4161          0.0725
+Dot Product           :          3.0514          0.5316
+Tea Solve             :        567.1188         98.7993
+Tea Reset             :          0.0452          0.0079
+Set Field             :          0.0000          0.0000
+Total                 :        573.9716         99.9931
+The Rest              :          0.0395          0.0069

--- a/2d/ext_pack_kernel.hpp
+++ b/2d/ext_pack_kernel.hpp
@@ -22,22 +22,22 @@ struct TopBottomPacker
 
 		if(face == CHUNK_TOP && pack)
 		{
-			offset = dims.x*(dims.y-HALO_PAD-depth) + lines*2*HALO_PAD;
+			offset = dims.x*(dims.y-HALO_PAD-depth) + lines*2*HALO_PAD + HALO_PAD;
 			buffer(index) = field(offset+index);
 		}
 		else if(face == CHUNK_BOTTOM && pack)
 		{
-			offset = dims.x*HALO_PAD + lines*2*HALO_PAD;
+			offset = dims.x*HALO_PAD + lines*2*HALO_PAD + HALO_PAD;
 			buffer(index) = field(offset+index);
 		}
 		else if (face == CHUNK_TOP)
 		{
-			offset = dims.x*(dims.y-HALO_PAD) + lines*2*HALO_PAD;
+			offset = dims.x*(dims.y-HALO_PAD) + lines*2*HALO_PAD + HALO_PAD;
 			field(offset+index)=buffer(index);
 		}
 		else
 		{
-			offset = dims.x*(HALO_PAD-depth) + lines*2*HALO_PAD;
+			offset = dims.x*(HALO_PAD-depth) + lines*2*HALO_PAD + HALO_PAD;
 			field(offset+index)=buffer(index);
 		}
 	}
@@ -68,22 +68,22 @@ struct LeftRightPacker
 
 		if(face == CHUNK_LEFT && pack)
 		{
-			offset = HALO_PAD + lines*(dims.x-depth);
+			offset = HALO_PAD + lines*(dims.x-depth) + HALO_PAD*dims.x;
 			buffer(index) = field(offset+index);
 		}
 		else if(face == CHUNK_RIGHT && pack)
 		{
-			offset = dims.x-HALO_PAD-depth + lines*(dims.x-depth);
+			offset = dims.x-HALO_PAD-depth + lines*(dims.x-depth) + HALO_PAD*dims.x;
 			buffer(index) = field(offset+index);
 		}
 		else if(face == CHUNK_LEFT)
 		{
-			offset = HALO_PAD-depth + lines*(dims.x-depth);
+			offset = HALO_PAD-depth + lines*(dims.x-depth) + HALO_PAD*dims.x;
 			field(offset+index)=buffer(index);
 		}
 		else
 		{
-			offset = dims.x-HALO_PAD + lines*(dims.x-depth);
+			offset = dims.x-HALO_PAD + lines*(dims.x-depth) + HALO_PAD*dims.x;
 			field(offset+index)=buffer(index);
 		}
 	}

--- a/2d/field_summary.f90
+++ b/2d/field_summary.f90
@@ -89,6 +89,12 @@ SUBROUTINE field_summary()
             !$ IF(OMP_GET_THREAD_NUM().EQ.0) THEN
             IF(test_problem.GE.1) THEN
 
+                IF(test_problem.EQ.1) qa_diff=ABS((100.0_8*(temp/157.55084183279294_8))-100.0_8)  !
+                IF(test_problem.EQ.2) qa_diff=ABS((100.0_8*(temp/106.27221178646569_8))-100.0_8)
+                IF(test_problem.EQ.3) qa_diff=ABS((100.0_8*(temp/99.955877498324000_8))-100.0_8)
+                IF(test_problem.EQ.4) qa_diff=ABS((100.0_8*(temp/97.277332050749976_8))-100.0_8)
+                IF(test_problem.EQ.5) qa_diff=ABS((100.0_8*(temp/95.462351583362249_8))-100.0_8)
+
                 IF(test_problem.EQ.6) qa_diff=ABS((100.0_8*(temp/103.88639125996923_8))-100.0_8) ! 500x500 20 steps
 
                 ! 32x32


### PR DESCRIPTION
The first commit is crucial as it fixes a bug when using MPI instead of OpenMP, as the packing/unpacking was wrong (we were packing halo cells / unpacking into halo cells)

The second commit is a minor issue, but helps to compare to the original TeaLeaf repository as we can use the benchmarks from there.